### PR TITLE
Feature/TW-916: Parent locations of Location Tree need to be able to be checked

### DIFF
--- a/app/containers/Network/index.js
+++ b/app/containers/Network/index.js
@@ -198,7 +198,7 @@ const Network = () => {
   };
 
   const onCheck = checkedKeys => {
-    setCheckedLocations(checkedKeys);
+    setCheckedLocations(checkedKeys.checked);
   };
 
   const locationsTree = useMemo(


### PR DESCRIPTION
JIRA: [TW-916](https://connectustechnologies.atlassian.net/browse/TW-916)

## Description
*Can check only the Parent Tree Node (independent of the child nodes) to show APs of that immediate location. I.e. uncheck all children of node, but parent node will still be checked.*

### Before this PR
![Screen Shot 2020-07-23 at 12 47 39 PM](https://user-images.githubusercontent.com/64545886/88314402-e1220600-cce2-11ea-8c65-0d2013d3c972.png)
![Screen Shot 2020-07-23 at 12 47 58 PM](https://user-images.githubusercontent.com/64545886/88314388-dbc4bb80-cce2-11ea-9811-1a8d44d06ff9.png)

### After this PR
*![Screen Shot 2020-07-23 at 12 45 53 PM](https://user-images.githubusercontent.com/64545886/88314410-e2ebc980-cce2-11ea-87d2-c0b5e09f930b.png)*