### PR TITLE
Hotfix/TW-959: Loading circle in wrong place for AP Details, Profiles, ProfileDetails components

### DIFF
--- a/app/containers/Network/containers/AccessPointDetails/index.js
+++ b/app/containers/Network/containers/AccessPointDetails/index.js
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 import { useQuery, useMutation } from '@apollo/react-hooks';
-import { Alert, Spin, notification } from 'antd';
+import { Alert, notification } from 'antd';
 import moment from 'moment';
-import { AccessPointDetails as AccessPointDetailsPage } from '@tip-wlan/wlan-cloud-ui-library';
+import {
+  AccessPointDetails as AccessPointDetailsPage,
+  Loading,
+} from '@tip-wlan/wlan-cloud-ui-library';
 
 import { FILTER_SERVICE_METRICS } from 'graphql/queries';
 import { UPDATE_EQUIPMENT_FIRMWARE } from 'graphql/mutations';
@@ -264,7 +267,7 @@ const AccessPointDetails = ({ locations }) => {
       );
 
   if (loading || landingProfiles || landingFirmware) {
-    return <Spin size="large" />;
+    return <Loading />;
   }
 
   if (error) {

--- a/app/containers/ProfileDetails/index.js
+++ b/app/containers/ProfileDetails/index.js
@@ -2,8 +2,8 @@ import React, { useState, useContext } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import gql from 'graphql-tag';
 import { useQuery, useMutation } from '@apollo/react-hooks';
-import { Alert, Spin, notification } from 'antd';
-import { ProfileDetails as ProfileDetailsPage } from '@tip-wlan/wlan-cloud-ui-library';
+import { Alert, notification } from 'antd';
+import { ProfileDetails as ProfileDetailsPage, Loading } from '@tip-wlan/wlan-cloud-ui-library';
 
 import UserContext from 'contexts/UserContext';
 import { GET_ALL_PROFILES } from 'graphql/queries';
@@ -146,7 +146,7 @@ const ProfileDetails = () => {
       );
 
   if (loading) {
-    return <Spin size="large" />;
+    return <Loading />;
   }
 
   if (error) {

--- a/app/containers/Profiles/index.js
+++ b/app/containers/Profiles/index.js
@@ -2,9 +2,9 @@ import React, { useContext } from 'react';
 import gql from 'graphql-tag';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 
-import { Alert, Spin, notification } from 'antd';
+import { Alert, notification } from 'antd';
 
-import { Profile as ProfilePage } from '@tip-wlan/wlan-cloud-ui-library';
+import { Profile as ProfilePage, Loading } from '@tip-wlan/wlan-cloud-ui-library';
 import UserContext from 'contexts/UserContext';
 
 const GET_ALL_PROFILES = gql`
@@ -92,7 +92,7 @@ const Profiles = () => {
   };
 
   if (loading) {
-    return <Spin size="large" />;
+    return <Loading />;
   }
 
   if (error) {


### PR DESCRIPTION


JIRA: [TW-959](https://connectustechnologies.atlassian.net/browse/TW-959)

## Description
*Fixed loading circle placement for AccessPointDetails, Profiles and ProfileDetails components*

### Before this PR
![image](https://user-images.githubusercontent.com/64545886/90049901-7c374b80-dca3-11ea-8502-c1f3262cde4b.png)


### After this PR
![Screen Shot 2020-08-12 at 1 58 35 PM](https://user-images.githubusercontent.com/64545886/90050335-0b446380-dca4-11ea-889a-bdfddde80327.png)
