### PR TITLE
hotfix/AddAP: filter_equipment query refetches after AP is added

### DIFF
--- a/app/containers/Network/index.js
+++ b/app/containers/Network/index.js
@@ -12,7 +12,12 @@ import ClientDeviceDetails from 'containers/Network/containers/ClientDeviceDetai
 import BulkEditAccessPoints from 'containers/Network/containers/BulkEditAccessPoints';
 
 import UserContext from 'contexts/UserContext';
-import { GET_ALL_LOCATIONS, GET_LOCATION, GET_ALL_PROFILES } from 'graphql/queries';
+import {
+  GET_ALL_LOCATIONS,
+  GET_LOCATION,
+  GET_ALL_PROFILES,
+  FILTER_EQUIPMENT,
+} from 'graphql/queries';
 import {
   CREATE_LOCATION,
   UPDATE_LOCATION,
@@ -37,12 +42,20 @@ const Network = () => {
   const [createLocation] = useMutation(CREATE_LOCATION);
   const [updateLocation] = useMutation(UPDATE_LOCATION);
   const [deleteLocation] = useMutation(DELETE_LOCATION);
-  const [createEquipment] = useMutation(CREATE_EQUIPMENT);
   const [checkedLocations, setCheckedLocations] = useState([]);
   const [deleteModal, setDeleteModal] = useState(false);
   const [editModal, setEditModal] = useState(false);
   const [addModal, setAddModal] = useState(false);
   const [apModal, setApModal] = useState(false);
+
+  const [createEquipment] = useMutation(CREATE_EQUIPMENT, {
+    refetchQueries: [
+      {
+        query: FILTER_EQUIPMENT,
+        variables: { customerId, locationIds: checkedLocations, equipmentType: 'AP' },
+      },
+    ],
+  });
 
   const handleGetSingleLocation = id => {
     getLocation({


### PR DESCRIPTION
JIRA: [ID](LINK)

## Description
*Summary of this PR
Had to manually refresh table when an AP was bound to a Location. Fixed it so table automatically refreshes. *

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*