### PR TITLE
hotfix/WIFI-679: Dashboard traffic has NaN values

### DIFF
--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -13,7 +13,7 @@ function formatBytes(bytes, decimals = 2) {
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
 
   // eslint-disable-next-line no-restricted-properties
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i] || ''}`;


### PR DESCRIPTION
JIRA: [WIFI-679](https://telecominfraproject.atlassian.net/browse/WIFI-679)

## Description
Use absolute value of bytes when determining exponent to remove `NaN` on traffic chart

### Before this PR
![Screen Shot 2020-08-21 at 3 02 19 PM](https://user-images.githubusercontent.com/69811026/90925583-80f4b180-e3bf-11ea-88a0-26135d2c4fbe.png)


### After this PR
![Screen Shot 2020-08-21 at 3 02 07 PM](https://user-images.githubusercontent.com/69811026/90925596-881bbf80-e3bf-11ea-806b-73fb8ddeefc1.png)
