### PR TITLE
WIFI-845: Support Kubernetes Deployment Versioning

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -13,6 +13,10 @@ on:
   # Run tests for any PRs.
   pull_request:
 
+  schedule:
+      # runs nightly build at 5AM
+      - cron:  '00 09 * * *'
+
 env:
   IMAGE_NAME: wlan-cloud-ui
   DOCKER_REPO: tip-tip-wlan-cloud-docker-repo.jfrog.io
@@ -56,6 +60,7 @@ jobs:
       - name: Push image
         run: |
           IMAGE_ID=$DOCKER_REPO/$IMAGE_NAME
+          TIMESTAMP=$(date +'%Y-%m-%d')
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
@@ -71,6 +76,10 @@ jobs:
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
+          echo TIMESTAMP=$TIMESTAMP
 
           docker tag image $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
+          
+          docker tag image $IMAGE_ID:$VERSION-$TIMESTAMP
+          docker push $IMAGE_ID:$VERSION-$TIMESTAMP          


### PR DESCRIPTION
JIRA: [WIFI-845](https://telecominfraproject.atlassian.net/jira/software/c/projects/WIFI/issues/WIFI-845?jql=project%20%3D%20%22WIFI%22%20AND%20%28text%20~%20%22845%22%20OR%20issuekey%3D%22WIFI-845%22%29%20%20ORDER%20BY%20created%20DESC)

## Description
Added nightly build to generate images with a timestamp. This is done so that the front-end and back-end components would have the same timestamp tag. The timestamp would then be used to test a deployment version for a specific day.

A nightly build would take place every day even if there are no commits for a day.  For more information refer https://telecominfraproject.atlassian.net/jira/software/c/projects/WIFI/issues/WIFI-911?jql=project%20%3D%20%22WIFI%22%20AND%20%28text%20~%20%22911%22%20OR%20issuekey%3D%22WIFI-911%22%29%20%20ORDER%20BY%20created%20DESC

### Screenshot
After this PR, we would have timestamp tags for the front-end components just like the back-end components have.

![image](https://user-images.githubusercontent.com/66637665/95367814-3792ef80-08a3-11eb-913c-4d9ce16ae6ec.png)
