### PR TITLE
hotfix/WIFI-1043: Usage info on dashboard shows total sum of traffic

### DIFF
--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -41,7 +41,7 @@ const lineChartConfig = [
   { key: 'clientDevices', title: 'Client Devices (24 hours)' },
   {
     key: 'traffic',
-    title: 'Traffic (24 hours)',
+    title: 'Usage Information (24 hours)',
     options: { formatter: trafficLabelFormatter, tooltipFormatter: trafficTooltipFormatter },
   },
 ];
@@ -88,6 +88,9 @@ const Dashboard = () => {
     },
   });
 
+  const [totalUpstreamTraffic, setTotalUpstreamTraffic] = useState(0);
+  const [totalDownstreamTraffic, setTotalDownstreamTraffic] = useState(0);
+
   const { loading: metricsLoading, error: metricsError, data: metricsData, fetchMore } = useQuery(
     FILTER_SYSTEM_EVENTS,
     {
@@ -110,7 +113,6 @@ const Dashboard = () => {
         const clientDevices5GHz = [];
         const trafficBytesDownstreamData = [];
         const trafficBytesUpstreamData = [];
-
         list.forEach(
           ({
             eventTimestamp,
@@ -135,6 +137,9 @@ const Dashboard = () => {
 
             trafficBytesDownstreamData.push([eventTimestamp, trafficBytesDownstream]);
             trafficBytesUpstreamData.push([eventTimestamp, trafficBytesUpstream]);
+
+            setTotalUpstreamTraffic(previous => previous + trafficBytesUpstream);
+            setTotalDownstreamTraffic(previous => previous + trafficBytesDownstream);
           }
         );
 
@@ -197,14 +202,11 @@ const Dashboard = () => {
 
   const statsArr = useMemo(() => {
     const status = data?.getAllStatus?.items[0]?.detailsJSON || {};
-
     const {
       associatedClientsCountPerRadio,
       totalProvisionedEquipment,
       equipmentInServiceCount,
       equipmentWithClientsCount,
-      trafficBytesDownstream,
-      trafficBytesUpstream,
     } = status;
 
     const clientRadios = {};
@@ -238,8 +240,8 @@ const Dashboard = () => {
       },
       {
         title: 'Usage Information',
-        'Total Traffic (US)': formatBytes(trafficBytesUpstream),
-        'Total Traffic (DS)': formatBytes(trafficBytesDownstream),
+        'Total Traffic (US)': formatBytes(totalUpstreamTraffic),
+        'Total Traffic (DS)': formatBytes(totalDownstreamTraffic),
       },
     ];
   }, [data]);

--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -113,6 +113,7 @@ const Dashboard = () => {
         const clientDevices5GHz = [];
         const trafficBytesDownstreamData = [];
         const trafficBytesUpstreamData = [];
+
         list.forEach(
           ({
             eventTimestamp,
@@ -202,6 +203,7 @@ const Dashboard = () => {
 
   const statsArr = useMemo(() => {
     const status = data?.getAllStatus?.items[0]?.detailsJSON || {};
+
     const {
       associatedClientsCountPerRadio,
       totalProvisionedEquipment,

--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -41,7 +41,7 @@ const lineChartConfig = [
   { key: 'clientDevices', title: 'Client Devices (24 hours)' },
   {
     key: 'traffic',
-    title: 'Usage Information (24 hours)',
+    title: 'Traffic (24 hours)',
     options: { formatter: trafficLabelFormatter, tooltipFormatter: trafficTooltipFormatter },
   },
 ];
@@ -241,7 +241,7 @@ const Dashboard = () => {
         ...clientRadios,
       },
       {
-        title: 'Usage Information',
+        title: 'Usage Information (24 hours)',
         'Total Traffic (US)': formatBytes(totalUpstreamTraffic),
         'Total Traffic (DS)': formatBytes(totalDownstreamTraffic),
       },


### PR DESCRIPTION
JIRA: [WIFI-1043](https://telecominfraproject.atlassian.net/secure/RapidBoard.jspa?rapidView=40&projectKey=WIFI&modal=detail&selectedIssue=WIFI-1043&assignee=5f93042addb0df006e8f3fed)

## Description
*Summary of this PR*
Usage info on dashboard now shows total sum of traffic within 24 hours.

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/73356579/98284206-c6605e00-1f6e-11eb-9caf-0262378cc20b.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/73356579/98284272-dbd58800-1f6e-11eb-947b-de23d0b0e907.png)