### PR TITLE
hotfix/WIFI-735 fixed refetching of profiles page

### DIFF
--- a/app/containers/Profiles/index.js
+++ b/app/containers/Profiles/index.js
@@ -35,7 +35,7 @@ const Profiles = () => {
   }, []);
 
   const reloadTable = () => {
-    refetch()
+    refetch({ variables: { uniqueRefresh: Math.random() } })
       .then(() => {
         notification.success({
           message: 'Success',

--- a/app/containers/Profiles/index.js
+++ b/app/containers/Profiles/index.js
@@ -34,8 +34,12 @@ const Profiles = () => {
     }
   }, []);
 
+  const refetchTableData = () => {
+    return refetch({ variables: { uniqueRefresh: Math.random() } });
+  };
+
   const reloadTable = () => {
-    refetch({ variables: { uniqueRefresh: Math.random() } })
+    refetchTableData()
       .then(() => {
         notification.success({
           message: 'Success',
@@ -66,7 +70,7 @@ const Profiles = () => {
           message: 'Success',
           description: 'Profile successfully deleted.',
         });
-        refetch();
+        refetchTableData();
       })
       .catch(() =>
         notification.error({


### PR DESCRIPTION
JIRA: [WIFI-735](https://telecominfraproject.atlassian.net/browse/WIFI-735)

## Description
*Summary of this PR*
- Reload button and after deleting profile, the profile table isn't refreshed properly

- Due to `refetch()` function using the same previous variables such as customerId, context, etc. 

Solution:
- pass a new unique variables in `refetch()` function that does not impact other variable (context, customerId, etc) of the query each time it is called. This allows `refetch()` to run each time it is clicked

- this is placed inside new `refetchTableData()` function

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*