### PR TITLE
bugfix/NETEXP-741: Passed down currentUserId to accounts page

### DIFF
--- a/app/containers/Accounts/index.js
+++ b/app/containers/Accounts/index.js
@@ -66,7 +66,7 @@ const DELETE_USER = gql`
 `;
 
 const Accounts = () => {
-  const { customerId } = useContext(UserContext);
+  const { customerId, id: currentUserId } = useContext(UserContext);
 
   const { data, loading, error, refetch, fetchMore } = useQuery(GET_ALL_USERS, {
     variables: { customerId },
@@ -173,6 +173,7 @@ const Accounts = () => {
   return (
     <AccountsPage
       data={data.getAllUsers.items}
+      currentUserId={currentUserId}
       onLoadMore={handleLoadMore}
       onCreateUser={handleCreateUser}
       onEditUser={handleEditUser}


### PR DESCRIPTION
JIRA: [NETEXP-741](https://connectustechnologies.atlassian.net/browse/NETEXP-741)

## Description
*Summary of this PR*
- The change to prevent deleting current user for the TIP side
- Passed down `currentUserId` prop to Accounts page of Library

- part of other PR of the library [NETEP-741 PR](https://github.com/Telecominfraproject/wlan-cloud-ui-library/pull/121)

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*