### PR TITLE
bugfix/NETEXP-783: AP table uses baseMacAddress and manufacturer

### DIFF
--- a/app/containers/Network/containers/AccessPointDetails/index.js
+++ b/app/containers/Network/containers/AccessPointDetails/index.js
@@ -42,16 +42,14 @@ const GET_EQUIPMENT = gql`
           details
         }
       }
+      baseMacAddress
+      manufacturer
       status {
         firmware {
           detailsJSON
         }
         protocol {
           detailsJSON
-          details {
-            reportedMacAddr
-            manufacturer
-          }
         }
         radioUtilization {
           detailsJSON

--- a/app/containers/Network/containers/AccessPoints/index.js
+++ b/app/containers/Network/containers/AccessPoints/index.js
@@ -59,7 +59,7 @@ const accessPointsTableColumns = [
   },
   {
     title: 'MAC',
-    dataIndex: ['baseMacAddress'],
+    dataIndex: 'baseMacAddress',
     render: renderTableCell,
   },
   {

--- a/app/containers/Network/containers/AccessPoints/index.js
+++ b/app/containers/Network/containers/AccessPoints/index.js
@@ -59,12 +59,12 @@ const accessPointsTableColumns = [
   },
   {
     title: 'MAC',
-    dataIndex: ['status', 'protocol', 'details', 'reportedMacAddr'],
+    dataIndex: ['baseMacAddress'],
     render: renderTableCell,
   },
   {
     title: 'MANUFACTURER',
-    dataIndex: ['status', 'protocol', 'details', 'manufacturer'],
+    dataIndex: 'manufacturer',
     render: renderTableCell,
   },
   {

--- a/app/graphql/queries.js
+++ b/app/graphql/queries.js
@@ -42,12 +42,12 @@ export const FILTER_EQUIPMENT = gql`
         profile {
           name
         }
+        baseMacAddress
+        manufacturer
         status {
           protocol {
             details {
               reportedIpV4Addr
-              reportedMacAddr
-              manufacturer
             }
           }
           osPerformance {


### PR DESCRIPTION
JIRA: [NETEXP-783](https://connectustechnologies.atlassian.net/browse/NETEXP-783)

## Description
*Summary of this PR*
- changed query of `FILTER_EQUIPMENT` and `GET_EQUIPMENT` to include new fields `baseMacAddress` and `manufacture`
- changed NetworkTable to use `baseMacAddress` and `manufactures` fields 

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*