### PR TITLE
bugfix/NETEXP-795: Added currentUserEmail prop & Altered Account title

### DIFF
--- a/app/containers/MasterLayout/index.js
+++ b/app/containers/MasterLayout/index.js
@@ -13,7 +13,7 @@ import { removeItem } from 'utils/localStorage';
 import UserContext from 'contexts/UserContext';
 
 const MasterLayout = ({ children }) => {
-  const { roles, customerId } = useContext(UserContext);
+  const { roles, customerId, email } = useContext(UserContext);
 
   const client = useApolloClient();
   const location = useLocation();
@@ -59,7 +59,7 @@ const MasterLayout = ({ children }) => {
         {
           key: 'editAccount',
           path: ROUTES.account,
-          text: 'Edit Account',
+          text: 'Account',
         },
         {
           key: 'logout',
@@ -90,6 +90,7 @@ const MasterLayout = ({ children }) => {
       menuItems={menuItems}
       mobileMenuItems={mobileMenuItems}
       totalAlarms={data && data.getAlarmCount}
+      currentUserEmail={email}
     >
       {children}
     </Layout>


### PR DESCRIPTION
JIRA: [NETEXP-795](https://connectustechnologies.atlassian.net/browse/NETEXP-795)

## Description
*Summary of this PR*
-passed down currentUserEmail prop down
-changed mobile menu item from Edit Account to Account
-part of library PR of [NETEXP-795](https://github.com/Telecominfraproject/wlan-cloud-ui-library/pull/130)

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="497" alt="Screen Shot 2020-12-16 at 5 30 54 PM" src="https://user-images.githubusercontent.com/70719869/102415071-8ce72d80-3fc5-11eb-8b3b-8244953eef15.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="501" alt="Screen Shot 2020-12-16 at 5 29 04 PM" src="https://user-images.githubusercontent.com/70719869/102415091-94a6d200-3fc5-11eb-8dfc-04ff8ff52041.png">
