### PR TITLE
bugfix/NETEXP-839: Added comparison to filter out negative values of the traffic graph

### DIFF
--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -129,11 +129,17 @@ const Dashboard = () => {
             clientDevices2dot4GHz.push([eventTimestamp, radios.is2dot4GHz || 0]);
             clientDevices5GHz.push([eventTimestamp, total5GHz || 0]);
 
-            trafficBytesDownstreamData.push([eventTimestamp, trafficBytesDownstream || 0]);
-            trafficBytesUpstreamData.push([eventTimestamp, trafficBytesUpstream || 0]);
+            trafficBytesDownstreamData.push([
+              eventTimestamp,
+              (trafficBytesDownstream > 0 && trafficBytesDownstream) || 0,
+            ]);
+            trafficBytesUpstreamData.push([
+              eventTimestamp,
+              (trafficBytesUpstream > 0 && trafficBytesUpstream) || 0,
+            ]);
 
-            totalDown += trafficBytesDownstream || 0;
-            totalUp += trafficBytesUpstream || 0;
+            totalDown += (trafficBytesDownstream > 0 && trafficBytesDownstream) || 0;
+            totalUp += (trafficBytesUpstream > 0 && trafficBytesUpstream) || 0;
           }
         );
 


### PR DESCRIPTION
JIRA: [NETEXP-839](https://connectustechnologies.atlassian.net/browse/NETEXP-839)

## Description
*Summary of this PR*
- same changes done in [CMAP PR](https://bitbucket.org/connectustechnologies/cmap-ui/pull-requests/59)  for the DashBoard Page
- Added another comparison to set negative values to 0 specifically for traffic graph as negative 0 Giga-Bytes or Mega-Bytes makes no sense

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*