### PR TITLE
bugfix/NETEXP-523: Passed down radius & captive profiles to AddProfile

### DIFF
--- a/app/containers/AddProfile/index.js
+++ b/app/containers/AddProfile/index.js
@@ -38,6 +38,18 @@ const AddProfile = () => {
   const { data: ssidProfiles, fetchMore } = useQuery(GET_ALL_PROFILES(), {
     variables: { customerId, type: 'ssid' },
   });
+  const { data: radiusProfiles, fetchMore: fetchMoreRadiusProfiles } = useQuery(
+    GET_ALL_PROFILES(),
+    {
+      variables: { customerId, type: 'radius' },
+    }
+  );
+  const { data: captiveProfiles, fetchMore: fetchMoreCaptiveProfiles } = useQuery(
+    GET_ALL_PROFILES(),
+    {
+      variables: { customerId, type: 'captive_portal' },
+    }
+  );
   const { data: venueProfiles, fetchMore: fetchMoreVenueProfiles } = useQuery(GET_ALL_PROFILES(), {
     variables: { customerId, type: 'passpoint_venue' },
   });
@@ -95,6 +107,42 @@ const AddProfile = () => {
     if (target.scrollTop + target.offsetHeight === target.scrollHeight) {
       fetchMore({
         variables: { context: { ...ssidProfiles.getAllProfiles.context } },
+        updateQuery: updateQueryGetAllProfiles,
+      });
+    }
+
+    return true;
+  };
+
+  const handleFetchRadiusProfiles = e => {
+    if (radiusProfiles.getAllProfiles.context.lastPage) {
+      return false;
+    }
+
+    e.persist();
+    const { target } = e;
+
+    if (target.scrollTop + target.offsetHeight === target.scrollHeight) {
+      fetchMoreRadiusProfiles({
+        variables: { context: { ...radiusProfiles.getAllProfiles.context } },
+        updateQuery: updateQueryGetAllProfiles,
+      });
+    }
+
+    return true;
+  };
+
+  const handleFetchCaptiveProfiles = e => {
+    if (captiveProfiles.getAllProfiles.context.lastPage) {
+      return false;
+    }
+
+    e.persist();
+    const { target } = e;
+
+    if (target.scrollTop + target.offsetHeight === target.scrollHeight) {
+      fetchMoreCaptiveProfiles({
+        variables: { context: { ...captiveProfiles.getAllProfiles.context } },
         updateQuery: updateQueryGetAllProfiles,
       });
     }
@@ -177,14 +225,16 @@ const AddProfile = () => {
   return (
     <AddProfilePage
       onCreateProfile={handleAddProfile}
-      ssidProfiles={
-        (ssidProfiles && ssidProfiles.getAllProfiles && ssidProfiles.getAllProfiles.items) || []
-      }
+      ssidProfiles={ssidProfiles?.getAllProfiles?.items}
+      radiusProfiles={radiusProfiles?.getAllProfiles?.items}
+      captiveProfiles={captiveProfiles?.getAllProfiles?.items}
       venueProfiles={venueProfiles?.getAllProfiles?.items}
       operatorProfiles={operatorProfiles?.getAllProfiles?.items}
       idProviderProfiles={idProviderProfiles?.getAllProfiles?.items}
       rfProfiles={rfProfiles?.getAllProfiles?.items}
       onFetchMoreProfiles={handleFetchProfiles}
+      onFetchMoreRadiusProfiles={handleFetchRadiusProfiles}
+      onFetchMoreCaptiveProfiles={handleFetchCaptiveProfiles}
       onFetchMoreVenueProfiles={handleFetchVenueProfiles}
       onFetchMoreOperatorProfiles={handleFetchOperatorProfiles}
       onFetchMoreIdProviderProfiles={handleFetchIdProviderProfiles}


### PR DESCRIPTION
JIRA: [NETEXP-523](https://connectustechnologies.atlassian.net/browse/NETEXP-523)

## Description
*Summary of this PR*
- Passed down Radius & Captive Profiles and their fetches to AddProfile page for SSID and Captive Portal profiles
- made `addProfile` more consistent with `profileDetails` to view  profile data

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1791" alt="Screen Shot 2021-01-05 at 10 46 33 AM" src="https://user-images.githubusercontent.com/70719869/103667420-e6e36f00-4f43-11eb-9750-72bc1e02b89b.png">
<img width="1791" alt="Screen Shot 2021-01-05 at 10 47 07 AM" src="https://user-images.githubusercontent.com/70719869/103667423-e945c900-4f43-11eb-8aa3-d7cf2fb4b5dd.png">
<img width="1791" alt="Screen Shot 2021-01-05 at 10 47 20 AM" src="https://user-images.githubusercontent.com/70719869/103667424-ea76f600-4f43-11eb-9660-2b78ab6cca43.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1791" alt="Screen Shot 2021-01-05 at 10 45 58 AM" src="https://user-images.githubusercontent.com/70719869/103667443-f06cd700-4f43-11eb-8616-7e1feee0b3ab.png">
<img width="1791" alt="Screen Shot 2021-01-05 at 10 46 33 AM" src="https://user-images.githubusercontent.com/70719869/103667447-f2369a80-4f43-11eb-9d9c-fa4b9aa4074e.png">
<img width="1791" alt="Screen Shot 2021-01-05 at 10 49 54 AM" src="https://user-images.githubusercontent.com/70719869/103667453-f2cf3100-4f43-11eb-8878-f8f06b61145b.png">
