### PR TITLE
hotfix/BulkEditTable: Added radioMap property to tableData array

### DIFF
--- a/app/containers/Network/containers/BulkEditAccessPoints/index.js
+++ b/app/containers/Network/containers/BulkEditAccessPoints/index.js
@@ -237,23 +237,20 @@ const BulkEditAPs = ({ locations, checkedLocations }) => {
     return minLoadValue;
   };
 
-  const setAccessPointsBulkEditTableData = (dataSource = []) => {
-    const tableData = dataSource.items.map(({ id: key, name, details }) => {
-      return {
-        key,
-        id: key,
-        name,
-        manualChannelNumber: getRadioDetails(details, 'manualChannelNumber'),
-        manualBackupChannelNumber: getRadioDetails(details, 'manualBackupChannelNumber'),
-        cellSize: getRadioDetails(details, 'cellSize'),
-        probeResponseThreshold: getRadioDetails(details, 'probeResponseThreshold'),
-        clientDisconnectThreshold: getRadioDetails(details, 'clientDisconnectThreshold'),
-        snrDrop: getRadioDetails(details, 'snrDrop'),
-        minLoad: getRadioDetails(details, 'minLoad'),
-      };
-    });
-    return tableData;
-  };
+  const setAccessPointsBulkEditTableData = (dataSource = []) =>
+    dataSource.items.map(({ id: key, name, details }) => ({
+      key,
+      id: key,
+      name,
+      manualChannelNumber: getRadioDetails(details, 'manualChannelNumber'),
+      manualBackupChannelNumber: getRadioDetails(details, 'manualBackupChannelNumber'),
+      cellSize: getRadioDetails(details, 'cellSize'),
+      probeResponseThreshold: getRadioDetails(details, 'probeResponseThreshold'),
+      clientDisconnectThreshold: getRadioDetails(details, 'clientDisconnectThreshold'),
+      snrDrop: getRadioDetails(details, 'snrDrop'),
+      minLoad: getRadioDetails(details, 'minLoad'),
+      radioMap: Object.keys(details?.radioMap || {}),
+    }));
 
   const setUpdatedBulkEditTableData = (
     equipmentId,
@@ -393,7 +390,7 @@ const BulkEditAPs = ({ locations, checkedLocations }) => {
   return (
     <BulkEditAccessPoints
       tableColumns={accessPointsChannelTableColumns}
-      tableData={setAccessPointsBulkEditTableData(equipData && equipData?.filterEquipment)}
+      tableData={setAccessPointsBulkEditTableData(equipData?.filterEquipment)}
       onLoadMore={handleLoadMore}
       isLastPage={equipData?.filterEquipment?.context?.lastPage}
       onSaveChanges={handleSaveChanges}


### PR DESCRIPTION
JIRA: [ID](LINK)

## Description
*Summary of this PR*

- Added `radioMap` property in tableData object. This is used for validation to ensure that the user can only enter the same number of inputs as there are radios for a given AP

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/111393312-e1667b80-868e-11eb-86ad-1bd146b3590e.png)

On this AP, there are only 2 supported radios, however users are able to input a maximum of 4. 

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/111393511-4621d600-868f-11eb-9ce8-54a4f984ab0f.png)


Now, users must input exactly how many radios there are for an AP. In this case 2. 