### PR TITLE
bugfix/WIFI-1755: Used correct dataIndex for AP Table Channels

### DIFF
--- a/app/containers/Network/containers/AccessPoints/index.js
+++ b/app/containers/Network/containers/AccessPoints/index.js
@@ -89,8 +89,8 @@ const accessPointsTableColumns = [
   },
   {
     title: 'CHANNEL',
-    dataIndex: 'channel',
-    render: renderTableCell,
+    dataIndex: ['status', 'channel', 'detailsJSON', 'channelNumberStatusDataMap'],
+    render: text => renderTableCell(Object.values(text ?? [])),
   },
   {
     title: 'OCCUPANCY',

--- a/app/graphql/queries.js
+++ b/app/graphql/queries.js
@@ -70,6 +70,9 @@ export const FILTER_EQUIPMENT = gql`
           firmware {
             detailsJSON
           }
+          channel {
+            detailsJSON
+          }
         }
       }
       context
@@ -120,6 +123,9 @@ export const GET_EQUIPMENT = gql`
           }
         }
         osPerformance {
+          detailsJSON
+        }
+        channel {
           detailsJSON
         }
       }


### PR DESCRIPTION
JIRA: [WIFI-1755](https://telecominfraproject.atlassian.net/browse/WIFI-1755)

## Description
*Summary of this PR*
- Used the correct data-index for Access Points table channels. Used the "RADIO_CHANNEL" status instead of using the channels from the details radioMap
- Added "RADIO_CHANNEL" status to `GET_EQUIPMENT` gql query to correctly display channels in AP Details status tab

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/111505622-3356e200-871f-11eb-9a35-e051d1617034.png)
![image](https://user-images.githubusercontent.com/55258316/111505665-3e117700-871f-11eb-8962-8fc5d5cd5fe3.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/111505521-14f0e680-871f-11eb-8104-95454e6aa75e.png)
![image](https://user-images.githubusercontent.com/55258316/111505558-220dd580-871f-11eb-9f3a-322274a82d70.png)
