### PR TITLE
bugfix/NETEXP-1296: Fixed refetching of service metrics data

### DIFF
--- a/app/containers/Network/containers/AccessPointDetails/index.js
+++ b/app/containers/Network/containers/AccessPointDetails/index.js
@@ -70,7 +70,7 @@ const AccessPointDetails = ({ locations }) => {
     loading: metricsLoading,
     error: metricsError,
     data: metricsData,
-    refetch: metricsRefetch,
+    fetchMore: fetchMoreServiceMetrics,
   } = useQuery(FILTER_SERVICE_METRICS, {
     variables: {
       customerId,
@@ -90,7 +90,29 @@ const AccessPointDetails = ({ locations }) => {
 
   const refetchData = () => {
     refetch();
-    metricsRefetch();
+    fetchMoreServiceMetrics({
+      variables: {
+        fromTime: moment()
+          .subtract(2, 'minutes')
+          .valueOf()
+          .toString(),
+        toTime: moment()
+          .valueOf()
+          .toString(),
+      },
+      updateQuery: (previousResult, { fetchMoreResult }) => {
+        const previousEntry = previousResult.filterServiceMetrics;
+        const newItems = fetchMoreResult.filterServiceMetrics.items;
+
+        return {
+          filterServiceMetrics: {
+            context: fetchMoreResult.filterServiceMetrics.context,
+            items: [...previousEntry.items, ...newItems],
+            __typename: previousEntry.__typename,
+          },
+        };
+      },
+    });
   };
 
   const handleUpdateEquipment = ({


### PR DESCRIPTION
JIRA: [NETEXP-1296](https://connectustechnologies.atlassian.net/browse/NETEXP-1296)

## Description
*Summary of this PR*

- Fixed bug on OS stats page that would not update the data used for the Stock Chart
- Instead of using a `refetch` , a `fetchMore` is used with new values within the last 2 minutes

### Before this PR
*Screenshots of what it looked like before this PR*

The Highcharts graph wouldn’t update the data on a per-minute basis. Note how it is 8:00 pm but the latest data in the chart shows 7:18 pm.

![Screen Shot 2021-03-23 at 8 00 32 PM](https://user-images.githubusercontent.com/55258316/112234302-9ad6cb00-8c12-11eb-8701-7e24562d805c.png)

### After this PR
*Screenshots of what it will look like after this PR*
The Highcharts graph correctly updates data every minute, and users are able to see the range of data from the moment they loaded the page.
![Screen Shot 2021-03-23 at 7 55 00 PM](https://user-images.githubusercontent.com/55258316/112234335-ab874100-8c12-11eb-8788-cd671da1a697.png)