### PR TITLE
hotfix/ScrollToTop: Added ScrollToTop  component

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Switch, Redirect } from 'react-router-dom';
 
-import { ThemeProvider, GenericNotFound } from '@tip-wlan/wlan-cloud-ui-library';
+import { ThemeProvider, GenericNotFound, ScrollToTop } from '@tip-wlan/wlan-cloud-ui-library';
 
 import logo from 'images/tip-logo.png';
 import logoMobile from 'images/tip-logo-mobile.png';
@@ -75,7 +75,7 @@ const App = () => {
         <Helmet titleTemplate={`%s - ${COMPANY}`} defaultTitle={COMPANY}>
           <meta name="description" content={COMPANY} />
         </Helmet>
-
+        <ScrollToTop />
         <Switch>
           <UnauthenticatedRoute exact path={ROUTES.login} component={Login} />
           <ProtectedRouteWithLayout exact path={ROUTES.root} component={RedirectToDashboard} />

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Switch, Redirect } from 'react-router-dom';
 
-import { ThemeProvider, GenericNotFound, ScrollToTop } from '@tip-wlan/wlan-cloud-ui-library';
+import { ThemeProvider, GenericNotFound } from '@tip-wlan/wlan-cloud-ui-library';
 
 import logo from 'images/tip-logo.png';
 import logoMobile from 'images/tip-logo-mobile.png';
@@ -75,7 +75,6 @@ const App = () => {
         <Helmet titleTemplate={`%s - ${COMPANY}`} defaultTitle={COMPANY}>
           <meta name="description" content={COMPANY} />
         </Helmet>
-        <ScrollToTop />
         <Switch>
           <UnauthenticatedRoute exact path={ROUTES.login} component={Login} />
           <ProtectedRouteWithLayout exact path={ROUTES.root} component={RedirectToDashboard} />

--- a/app/index.js
+++ b/app/index.js
@@ -14,6 +14,7 @@ import { AUTH_TOKEN } from 'constants/index';
 import { REFRESH_TOKEN } from 'graphql/mutations';
 import { getItem, setItem, removeItem } from 'utils/localStorage';
 import history from 'utils/history';
+import { ScrollToTop } from '@tip-wlan/wlan-cloud-ui-library';
 
 const API_URI = process.env.NODE_ENV === 'production' ? window.REACT_APP_API : process.env.API;
 const MOUNT_NODE = document.getElementById('root');
@@ -102,6 +103,7 @@ const render = () => {
   ReactDOM.render(
     <Router history={history}>
       <ApolloProvider client={client}>
+        <ScrollToTop />
         <App />
       </ApolloProvider>
     </Router>,


### PR DESCRIPTION
NO-JIRA 

## Description
*Summary of this PR*
Throughout the site, when there is a  long content page, it stays scrolled down when navigated to if the previous page was also scrolled. Fixed this by adding a `ScrollToTop` component that resets the scroll upon route change.

Dependent on: https://github.com/Telecominfraproject/wlan-cloud-ui-library/pull/260

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*